### PR TITLE
feat: BoundEndpointPoller polls from the API

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -469,7 +469,7 @@ func enableGatewayFeatureSet(_ context.Context, _ managerOpts, mgr ctrl.Manager,
 }
 
 // enableBindingsFeatureSet enables the Bindings feature set for the operator
-func enableBindingsFeatureSet(ctx context.Context, opts managerOpts, mgr ctrl.Manager, _ *store.Driver, _ ngrokapi.Clientset) error {
+func enableBindingsFeatureSet(_ context.Context, opts managerOpts, mgr ctrl.Manager, _ *store.Driver, ngrokClientset ngrokapi.Clientset) error {
 	targetServiceAnnotations, err := util.ParseHelmDictionary(opts.bindings.serviceAnnotations)
 	if err != nil {
 		setupLog.WithValues("serviceAnnotations", opts.bindings.serviceAnnotations).Error(err, "unable to parse service annotations")
@@ -508,6 +508,7 @@ func enableBindingsFeatureSet(ctx context.Context, opts managerOpts, mgr ctrl.Ma
 		TargetServiceAnnotations:     targetServiceAnnotations,
 		TargetServiceLabels:          targetServiceLabels,
 		PollingInterval:              5 * time.Minute,
+		NgrokClientset:               ngrokClientset,
 		// NOTE: This range must stay static for the current implementation.
 		PortRange: bindingscontroller.PortRangeConfig{Min: 10000, Max: 65535},
 	}); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/golang/mock v1.4.4
 	github.com/google/uuid v1.3.1
 	github.com/imdario/mergo v0.3.16
-	github.com/ngrok/ngrok-api-go/v6 v6.1.1-0.20241025160627-dcdb6f5b23f8
+	github.com/ngrok/ngrok-api-go/v6 v6.1.1-0.20241031154501-292c6f1e1a7a
 	github.com/onsi/ginkgo/v2 v2.14.0
 	github.com/onsi/gomega v1.30.0
 	github.com/spf13/cobra v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -416,8 +416,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/nbutton23/zxcvbn-go v0.0.0-20180912185939-ae427f1e4c1d/go.mod h1:o96djdrsSGy3AWPyBgZMAGfxZNfgntdJG+11KU4QvbU=
-github.com/ngrok/ngrok-api-go/v6 v6.1.1-0.20241025160627-dcdb6f5b23f8 h1:HHfIX3/eXsnxwSxXpLJFSUO5sXWwxdNIkWVMsQd5f7o=
-github.com/ngrok/ngrok-api-go/v6 v6.1.1-0.20241025160627-dcdb6f5b23f8/go.mod h1:KtRxWqEomaHZfgeS+q/7nFHF+gPYFghS5wTl5AIUjIk=
+github.com/ngrok/ngrok-api-go/v6 v6.1.1-0.20241031154501-292c6f1e1a7a h1:u7nKkWkF1q9ircyXDnks+hdq0S8s61qcyAlgsUf1Jk0=
+github.com/ngrok/ngrok-api-go/v6 v6.1.1-0.20241031154501-292c6f1e1a7a/go.mod h1:KtRxWqEomaHZfgeS+q/7nFHF+gPYFghS5wTl5AIUjIk=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=

--- a/internal/controller/bindings/boundendpoint_poller.go
+++ b/internal/controller/bindings/boundendpoint_poller.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
+	"github.com/ngrok/ngrok-api-go/v6"
 	v6 "github.com/ngrok/ngrok-api-go/v6"
 	bindingsv1alpha1 "github.com/ngrok/ngrok-operator/api/bindings/v1alpha1"
 	ngrokv1alpha1 "github.com/ngrok/ngrok-operator/api/ngrok/v1alpha1"
@@ -43,6 +44,9 @@ type BoundEndpointPoller struct {
 
 	// KubernetesOperatorConfigName is the expected name of the KubernetesOperator that we should poll
 	KubernetesOperatorConfigName string
+
+	// NgrokClientset is the ngrok API clientset
+	NgrokClientset ngrokapi.Clientset
 
 	// PollingInterval is how often to poll the ngrok API for reconciling the BindingEndpoints
 	PollingInterval time.Duration
@@ -163,18 +167,24 @@ func (r *BoundEndpointPoller) reconcileBoundEndpointsFromAPI(ctx context.Context
 		r.reconcilingCancel() // cancel the previous reconcile loop
 	}
 
+	if r.koId == "" {
+		return nil
+	}
+
 	// Fetch the mock endpoint data from the API
-	resp, err := fetchEndpoints()
+	var apiBindingEndpoints []v6.Endpoint
+	iter := r.NgrokClientset.KubernetesOperators().GetBoundEndpoints(r.koId, &ngrok.Paging{})
+	for iter.Next(ctx) {
+		item := iter.Item()
+		if item != nil {
+			apiBindingEndpoints = append(apiBindingEndpoints, *item)
+		}
+	}
+
+	err := iter.Err()
 	if err != nil {
 		log.Error(err, "Failed to fetch binding_endpoints from API")
 		return err
-	}
-
-	var apiBindingEndpoints []v6.Endpoint
-	if resp.BindingEndpoints == nil {
-		apiBindingEndpoints = []v6.Endpoint{} // empty
-	} else {
-		apiBindingEndpoints = resp.BindingEndpoints.Endpoints
 	}
 
 	desiredBoundEndpoints, err := ngrokapi.AggregateBindingEndpoints(apiBindingEndpoints)
@@ -545,29 +555,4 @@ func boundEndpointNeedsUpdate(existing bindingsv1alpha1.BoundEndpoint, desired b
 func hashURI(uri string) string {
 	uid := uuid.NewSHA1(uuid.NameSpaceURL, []byte(uri))
 	return "ngrok-" + uid.String()
-}
-
-// fetchEndpoints mocks an API call to retrieve a list of endpoint bindings.
-func fetchEndpoints() (*MockApiResponse, error) {
-	// TODO(hkatz): Implement the actual API call to fetch the binding_epndoints
-	// Mock response with sample data.
-	return &MockApiResponse{
-		BindingEndpoints: &v6.EndpointList{
-			Endpoints: []v6.Endpoint{
-				{ID: "ep_100", PublicURL: "https://service1.namespace1"},
-				{ID: "ep_101", PublicURL: "https://service1.namespace1"},
-				{ID: "ep_102", PublicURL: "https://service1.namespace1"},
-				{ID: "ep_200", PublicURL: "tcp://service2.namespace2:2020"},
-				{ID: "ep_201", PublicURL: "tcp://service2.namespace2:2020"},
-				{ID: "ep_300", PublicURL: "service3.namespace3"},
-				{ID: "ep_400", PublicURL: "http://service4.namespace4:8080"},
-				{ID: "ep_500", PublicURL: "http://example-files.example:80"},
-			},
-		},
-	}, nil
-}
-
-// MockApiResponse represents a mock response from the API.
-type MockApiResponse struct {
-	BindingEndpoints *v6.EndpointList
 }


### PR DESCRIPTION
## What

This replaces the mock endpoints we had for testing with actually polling the API for bound endpoints.

## How

* Pass the ngrokclientset into the poller
* Replace the mock endpoints we had with the results returned from the API

## Breaking Changes
No
